### PR TITLE
2021年度の記事退避 #34

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -69,7 +69,7 @@ function add_old_content_notice($the_content) {
 		//除外する過去記事タグ処理
 		////////////////////////////
 		$define_not_tag_names = array(
-			'2017', '2018', '2019',
+			'2017', '2018', '2019', '2021',
 		);
 		
 		$tags = get_the_tags(); // 記事のタグ名を取得

--- a/index.php
+++ b/index.php
@@ -123,7 +123,7 @@ Template Name: トップページ
 				'2017',
 				'2018',
 				'2019',
-        '2021',
+				'2021',
 			);
 			$current_tags   = get_tags();
 			$ignore_tag_ids = array();

--- a/index.php
+++ b/index.php
@@ -123,6 +123,7 @@ Template Name: トップページ
 				'2017',
 				'2018',
 				'2019',
+        '2021',
 			);
 			$current_tags   = get_tags();
 			$ignore_tag_ids = array();

--- a/page-2021top.php
+++ b/page-2021top.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * 2021年のトップページを表示するテンプレート
+ *
+ * @package NGF
+ */
+
+get_header(); // header.phpを取得. ?>
+<?php
+// 必要情報を指定して 過去トップテンプレートを呼び出す.
+set_query_var( 'old_year', 2021 );
+set_query_var( 'old_header_youtube_video_id', 'VcQjxGRn2S8' );
+set_query_var( 'old_event_date', '2021.8.28(土)' );
+set_query_var( 'old_about_content', '第8回を迎えた名古屋ギターフェスティバル、今年も2公演でお届けします。昨年は残念ながら中止となってしまいましたが今年はパワーアップして様々な工夫を凝らして帰ってきます！' );
+get_template_part( 'template/top/old', 'index' );
+?>
+<?php
+set_query_var( 'footer_is_cv', false );
+get_footer(); // footer.phpを取得.


### PR DESCRIPTION
#34 

# 作業

* 記事に2021タグをつける
* `wordpress/wp-content/themes/ngf/index.php`で2021タグを除外する
* シングルページかつ古い記事の場合 注釈追加に2021タグを追加 `wordpress/wp-content/themes/ngf/functions.php`
* 2021固定ページを追加して`2021top`というスラグにする
* フッターメニューに↑を追加
* `page-2021top.php`を追加